### PR TITLE
add methods allowpagetemp and allowpage

### DIFF
--- a/plugin/noscript.js
+++ b/plugin/noscript.js
@@ -122,6 +122,14 @@ function NoscriptVimperator() {
       noscriptOverlay.toggleCurrentPage(3);
     },
 
+    allowpagetemp: function(){
+      noscriptOverlay.allowPage();
+    },
+
+    allowpage: function(){
+      noscriptOverlay.allowPage(true);
+    },
+
     toggleperm: function(){
       const ns = noscriptOverlay.ns;
       const url = ns.getQuickSite(content.document.documentURI, /*level*/ 3);


### PR DESCRIPTION
I find really useful use `Temporarily allow all this page`.
It use the function `allowPage: function(permanent, justTell, sites)` without any parameters.

The behaviour is different from the actual `toggletemp` command, that use `toggleCurrentPage: function(forceLevel)`.

The former **toggle all blocked** scripts *ON* (in the current page).
